### PR TITLE
Implement function to get list of read files

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -42,6 +42,17 @@
     "https://deno.land/std@0.162.0/path/win32.ts": "ee8826dce087d31c5c81cd414714e677eb68febc40308de87a2ce4b40e10fb8d",
     "https://deno.land/std@0.162.0/testing/_diff.ts": "a23e7fc2b4d8daa3e158fa06856bedf5334ce2a2831e8bf9e509717f455adb2c",
     "https://deno.land/std@0.162.0/testing/_format.ts": "cd11136e1797791045e639e9f0f4640d5b4166148796cad37e6ef75f7d7f3832",
-    "https://deno.land/std@0.162.0/testing/asserts.ts": "1e340c589853e82e0807629ba31a43c84ebdcdeca910c4a9705715dfdb0f5ce8"
+    "https://deno.land/std@0.162.0/testing/asserts.ts": "1e340c589853e82e0807629ba31a43c84ebdcdeca910c4a9705715dfdb0f5ce8",
+    "https://deno.land/std@0.181.0/_util/asserts.ts": "178dfc49a464aee693a7e285567b3d0b555dc805ff490505a8aae34f9cfb1462",
+    "https://deno.land/std@0.181.0/_util/os.ts": "d932f56d41e4f6a6093d56044e29ce637f8dcc43c5a90af43504a889cf1775e3",
+    "https://deno.land/std@0.181.0/path/_constants.ts": "e49961f6f4f48039c0dfed3c3f93e963ca3d92791c9d478ac5b43183413136e0",
+    "https://deno.land/std@0.181.0/path/_interface.ts": "6471159dfbbc357e03882c2266d21ef9afdb1e4aa771b0545e90db58a0ba314b",
+    "https://deno.land/std@0.181.0/path/_util.ts": "d7abb1e0dea065f427b89156e28cdeb32b045870acdf865833ba808a73b576d0",
+    "https://deno.land/std@0.181.0/path/common.ts": "ee7505ab01fd22de3963b64e46cff31f40de34f9f8de1fff6a1bd2fe79380000",
+    "https://deno.land/std@0.181.0/path/glob.ts": "d479e0a695621c94d3fd7fe7abd4f9499caf32a8de13f25073451c6ef420a4e1",
+    "https://deno.land/std@0.181.0/path/mod.ts": "bf718f19a4fdd545aee1b06409ca0805bd1b68ecf876605ce632e932fe54510c",
+    "https://deno.land/std@0.181.0/path/posix.ts": "8b7c67ac338714b30c816079303d0285dd24af6b284f7ad63da5b27372a2c94d",
+    "https://deno.land/std@0.181.0/path/separator.ts": "0fb679739d0d1d7bf45b68dacfb4ec7563597a902edbaf3c59b50d5bcadd93b1",
+    "https://deno.land/std@0.181.0/path/win32.ts": "d186344e5583bcbf8b18af416d13d82b35a317116e6460a5a3953508c3de5bba"
   }
 }

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -356,7 +356,7 @@ class Sass implements SassObject {
     return this;
   }
 
-  public getReadFiles() {
+  public get_read_files() {
     return Array.from(readFiles);
   }
 }

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -18,6 +18,7 @@ import {
   SassOptions,
 } from './types/module.types.ts';
 import { FileWritter } from './FileWritter.ts';
+import { readFiles } from './wasm/fileHandler.js';
 
 export const warn = (msg: string) =>
   console.warn(
@@ -111,6 +112,9 @@ class Sass implements SassObject {
       error(`No Output mode has been set during the process.`);
       return false;
     }
+
+    readFiles.clear();
+
     if (typeof format !== 'undefined') this.options.style = format;
     if (typeof this.#current === 'string' || this.#current instanceof Map) {
       if (this.#outmode === 1) {
@@ -156,6 +160,9 @@ class Sass implements SassObject {
       error(`No Output mode has been set during the process.`);
       return false;
     }
+
+    readFiles.clear();
+
     if (typeof format !== 'undefined') this.options.style = format;
     if (this.#outmode === 1) {
       if (this.#mode === 'string') {
@@ -197,6 +204,9 @@ class Sass implements SassObject {
       error(`The output dir string is empty`);
       Deno.exit(1);
     }
+
+    readFiles.clear();
+
     const outDirpath = path.normalize(outputOptions.destDir);
     let outFileExt = '';
     if (exists(outDirpath, 'dir')) {
@@ -344,6 +354,10 @@ class Sass implements SassObject {
     });
     this.#outmode = 2;
     return this;
+  }
+
+  public getReadFiles() {
+    return Array.from(readFiles);
   }
 }
 /**

--- a/src/wasm/fileHandler.js
+++ b/src/wasm/fileHandler.js
@@ -1,0 +1,49 @@
+import * as posix from "https://deno.land/std@0.181.0/path/mod.ts";
+
+const toPathUrl = function(path) {
+  return posix.toFileUrl(posix.resolve(path), posix.resolve(path, Deno.cwd()));
+}
+
+/** @type Set<string> */
+const readFiles = new Set();
+
+const readFile = function (path) {
+  const url = posix.isAbsolute(path) ? toPathUrl(path) : path;
+
+  readFiles.add(path);
+
+  if (isFile(path)) {
+    return Deno.readTextFileSync(url);
+  } else {
+    return '';
+  }
+}
+
+const isFile = function(path) {
+  const url = posix.isAbsolute(path) ? toPathUrl(path) : path;
+
+  try {
+    const file = Deno.statSync(url);
+    return file.isFile;
+  } catch {
+    return false;
+  }
+}
+
+const isDirectory = function (path) {
+  const url = posix.isAbsolute(path) ? toPathUrl(path) : path;
+
+  try {
+    const file = Deno.statSync(url);
+    return file.isDirectory;
+  } catch {
+    return false;
+  }
+}
+
+export {
+  readFiles,
+  readFile,
+  isFile,
+  isDirectory,
+};

--- a/src/wasm/grass.deno.js
+++ b/src/wasm/grass.deno.js
@@ -1,65 +1,11 @@
 // deno-lint-ignore-file
-
 import * as path from "https://deno.land/std@0.131.0/path/mod.ts";
-
-function js_read_fs(importpath) {
-  let url;
-  if (path.isAbsolute(importpath)) {
-    url = path.toFileUrl(
-      path.resolve(importpath),
-      path.resolve(importpath, Deno.cwd()),
-    );
-  } else {
-    url = importpath;
-  }
-  if (js_is_file(importpath)) {
-    const file = Deno.readTextFileSync(url);
-    return file;
-  } else {
-    return "";
-  }
-}
-
-function js_is_file(importpath) {
-  if (path.isAbsolute(importpath)) {
-    const url = path.toFileUrl(
-      path.resolve(importpath),
-      path.resolve(importpath, Deno.cwd()),
-    );
-    try {
-      const file = Deno.statSync(url);
-      return file.isFile;
-    } catch {
-      return false;
-    }
-  } else {
-    try {
-      const file = Deno.statSync(importpath);
-      return file.isFile;
-    } catch {
-      return false;
-    }
-  }
-}
-
-function js_is_dir(importpath) {
-  if (path.isAbsolute(importpath)) {
-    const url = path.toFileUrl(importpath);
-    try {
-      const file = Deno.statSync(url);
-      return file.isDirectory;
-    } catch {
-      return false;
-    }
-  } else {
-    try {
-      const file = Deno.statSync(importpath);
-      return file.isDirectory;
-    } catch {
-      return false;
-    }
-  }
-}
+import {
+  readFiles,
+  readFile as js_read_fs,
+  isFile as js_is_file,
+  isDirectory as js_is_dir
+} from './fileHandler.js';
 
 const cachedTextDecoder = new TextDecoder("utf-8", {
   ignoreBOM: true,


### PR DESCRIPTION
Implemented the function to get list of files loaded by `@import` statement.

Many bundlers such as esbuild have the ability to watch for file changes and rebuild. To do this, the name of the file to be read must be passed to them.

After running `Sass.to_string`, `Sass.to_buffer` or `Sass.to_file`, we can get read files using `Sass.get_read_files`.